### PR TITLE
Fix es6 function folding

### DIFF
--- a/lib/fold-functions.coffee
+++ b/lib/fold-functions.coffee
@@ -86,7 +86,9 @@ module.exports = AtomFoldFunctions =
       if foldable
         hasFoldableLines = true
 
-      isFunction = @hasScopeAtBufferRow(editor, row, 'meta.function')
+      isFunction = @hasScopeAtBufferRow(editor, row,
+      'meta.function', 'meta.method.js',
+      'storage.type.arrow.js', 'entity.name.function.constructor.js')
       if foldable and isFunction and not isCommented
         if @indentLevel == null
           @indentLevel = thisIndentLevel
@@ -103,7 +105,13 @@ module.exports = AtomFoldFunctions =
   unfold: ->
     @fold('unfold')
 
-  hasScopeAtBufferRow: (editor, row, scope) ->
+  hasScopeAtBufferRow: (editor, row, scopes...) ->
+    for scope in scopes
+      if this._hasScopeAtBufferRow(editor, row, scope)
+        return true
+    false
+
+  _hasScopeAtBufferRow: (editor, row, scope) ->
     found = false
     text = editor.lineTextForBufferRow(row).trim()
     if text.length > 0

--- a/lib/fold-functions.coffee
+++ b/lib/fold-functions.coffee
@@ -87,8 +87,8 @@ module.exports = AtomFoldFunctions =
         hasFoldableLines = true
 
       isFunction = @hasScopeAtBufferRow(editor, row,
-      'meta.function', 'meta.method.js',
-      'storage.type.arrow.js', 'entity.name.function.constructor.js')
+      'meta.function', 'meta.method',
+      'storage.type.arrow', 'entity.name.function.constructor')
       if foldable and isFunction and not isCommented
         if @indentLevel == null
           @indentLevel = thisIndentLevel


### PR DESCRIPTION
Fixes #5

For class methods, I'm not sure if which of "meta.method.js", "entity.name.function.js" should be used, however, the only scope available on constructors is 'entity.name.function.constructor.js', but you're already using "meta.function.js".

misc: for checking scopes, the devtools oneliner is

```
atom.workspace.getActiveTextEditor().scopeDescriptorForBufferPosition(atom.workspace.getActiveTextEditor().getCursors()[0].getBufferPosition()).scopes
```
