### PR TITLE
Check previous row for functions

### DIFF
--- a/lib/fold-functions.coffee
+++ b/lib/fold-functions.coffee
@@ -218,6 +218,12 @@ module.exports = AtomFoldFunctions =
         row,
         scopes
       )
+      if !isFunction and row > 1
+        isFunction = @hasScopeAtBufferRow(
+          editor,
+          row - 1,
+          scopes
+        )
       @debugMessage 'fold functions: is foldable',
         lines,
         (foldable and isFunction and not isCommented),


### PR DESCRIPTION
Straightforward attempt to fix #14 

Maybe we can narrow to `php` or even check if the line has `punctuation.definition.class.begin.bracket.curly.php` scope

Note. It is just a simple hack if you want to put the logic somewhere else, let me know